### PR TITLE
use nodeSelector and add toleration

### DIFF
--- a/kubefunc.bash
+++ b/kubefunc.bash
@@ -38,22 +38,8 @@ function kube-staging-prod-configs() {
 function kube-node-admin() {
   NODE=$1
   [[ -n "${NODE}" ]] && read -r -d '' SPEC_AFFINITY <<- EOM
-    "affinity": {
-      "nodeAffinity": {
-        "requiredDuringSchedulingIgnoredDuringExecution": {
-          "nodeSelectorTerms": [
-            {
-              "matchExpressions": [
-                {
-                  "key": "kubernetes.io/hostname",
-                  "operator": "In",
-                  "values": [ "${NODE}" ]
-                }
-              ]
-            }
-          ]
-        }
-      }
+    "nodeSelector": {
+      "kubernetes.io/hostname": "${NODE}"
     },
 EOM
 

--- a/node-admin/node-admin.sh
+++ b/node-admin/node-admin.sh
@@ -19,31 +19,24 @@ function _kube_list_nodes() {
 
 function kube-node-admin() {
   NODE=$1
-  [[ -n "${NODE}" ]] && read -r -d '' SPEC_AFFINITY <<- EOM
-    "affinity": {
-      "nodeAffinity": {
-        "requiredDuringSchedulingIgnoredDuringExecution": {
-          "nodeSelectorTerms": [
-            {
-              "matchExpressions": [
-                {
-                  "key": "kubernetes.io/hostname",
-                  "operator": "In",
-                  "values": [ "${NODE}" ]
-                }
-              ]
-            }
-          ]
-        }
-      }
+  [[ -n "${NODE}" ]] && read -r -d '' SPEC_NODE_SELECTOR <<- EOM
+    "nodeSelector": {
+      "kubernetes.io/hostname": "${NODE}"
     },
+    "tolerations": [
+      {
+        "effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/master",
+        "operator": "Exists"
+      }
+    ],
 EOM
 
   read -r -d '' SPEC_JSON <<EOF
 {
   "apiVersion": "v1",
   "spec": {
-    ${SPEC_AFFINITY}
+    ${SPEC_NODE_SELECTOR}
     "hostNetwork": true,
     "containers": [{
       "name": "node-admin",

--- a/node-admin/node-admin.sh
+++ b/node-admin/node-admin.sh
@@ -23,13 +23,6 @@ function kube-node-admin() {
     "nodeSelector": {
       "kubernetes.io/hostname": "${NODE}"
     },
-    "tolerations": [
-      {
-        "effect": "NoSchedule",
-        "key": "node-role.kubernetes.io/master",
-        "operator": "Exists"
-      }
-    ],
 EOM
 
   read -r -d '' SPEC_JSON <<EOF
@@ -37,6 +30,12 @@ EOM
   "apiVersion": "v1",
   "spec": {
     ${SPEC_NODE_SELECTOR}
+    "tolerations": [
+      {
+        "effect": "NoSchedule",
+        "operator": "Exists"
+      }
+    ],
     "hostNetwork": true,
     "containers": [{
       "name": "node-admin",


### PR DESCRIPTION
Hi @danisla !

First, thanks for this great plugin.

This PR aims to replace `affinity` by [nodeSelector ](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) (which is now the simplest way to affect a pod to a node) and to add toleration to allow scheduling on master nodes.