### PR TITLE
This should? (not 100% sure) fix the `krew` plugin entitled `debug-shell`

### DIFF
--- a/debug-shell/debug-shell.sh
+++ b/debug-shell/debug-shell.sh
@@ -2,4 +2,8 @@
 
 IMAGE=${1:-centos:latest}
 
-kubectl run -n ${KUBECTL_PLUGINS_CURRENT_NAMESPACE} -it --rm --restart=Never kube-shell --image ${IMAGE} -- bash
+# This has been modified to work with the post 1.12 extended plugin model
+# Also attach=true causes kubectl to not die out complaining about --rm
+# in spite of the fact that -i is supposed to set attach=true?
+
+kubectl run --attach=true -it --rm --restart=Never kube-shell --image ${IMAGE} -- bash


### PR DESCRIPTION
`kubectl krew debug-shell` seems to be non-functional in k8s 1.22.x.  I'm sure it has been broken a while.  I fixed it.  Now I'm contributing back.  

Please don't hesitate to reach out with any questions, comments, or concerns.

Regards,
--Randall